### PR TITLE
Get `secd` and `trustd` to build

### DIFF
--- a/OSX/sec/CMakeLists.txt
+++ b/OSX/sec/CMakeLists.txt
@@ -194,22 +194,24 @@ add_darling_static_library(secipc_client FAT
 )
 
 add_darling_executable(secipc_server ipc/server.c)
+set_target_properties(secipc_server PROPERTIES OUTPUT_NAME "secd")
 target_link_libraries(secipc_server system CoreFoundation
     SecTrustOSX securityd xpc sqlite3 utilities_sec_item_shim CFNetwork SecItemShimOSX
     security_keychain_DER SecureObjectSync z IOKit secipc_client
     LocalAuthentication objc CryptoTokenKit SystemConfiguration
     security_asn1 bsm.0 AppleSystemInfo Security)
-install(TARGETS secipc_server DESTINATION libexec/darling/usr/libexec RENAME secd)
+install(TARGETS secipc_server DESTINATION libexec/darling/usr/libexec)
 install(FILES ipc/com.apple.secd.plist DESTINATION libexec/darling/System/Library/LaunchDaemons)
 
 add_darling_executable(trustd_server ipc/server.c)
+set_target_properties(trustd_server PROPERTIES OUTPUT_NAME "trustd")
 target_compile_definitions(trustd_server PRIVATE TRUSTD_SERVER)
 target_link_libraries(trustd_server system CoreFoundation
     SecTrustOSX securityd xpc sqlite3 utilities_sec_item_shim CFNetwork SecItemShimOSX
     security_keychain_DER SecureObjectSync z IOKit secipc_client
     LocalAuthentication objc CryptoTokenKit SystemConfiguration
     security_asn1 bsm.0 AppleSystemInfo Security)
-install(TARGETS trustd_server DESTINATION libexec/darling/usr/libexec RENAME trustd)
+install(TARGETS trustd_server DESTINATION libexec/darling/usr/libexec)
 install(FILES ../trustd/com.apple.trustd.plist DESTINATION libexec/darling/System/Library/LaunchDaemons)
 install(FILES ../trustd/com.apple.trustd.agent.plist DESTINATION libexec/darling/System/Library/LaunchAgents)
 

--- a/OSX/sec/CMakeLists.txt
+++ b/OSX/sec/CMakeLists.txt
@@ -192,14 +192,26 @@ add_darling_static_library(secipc_client FAT
 	SOURCES
 		ipc/client.c
 )
+
 add_darling_executable(secipc_server ipc/server.c)
-target_link_libraries(secipc_server system Security CoreFoundation
-    SecTrustOSX securityd xpc sqlite3 utilities CFNetwork SecItemShimOSX
+target_link_libraries(secipc_server system CoreFoundation
+    SecTrustOSX securityd xpc sqlite3 utilities_sec_item_shim CFNetwork SecItemShimOSX
     security_keychain_DER SecureObjectSync z IOKit secipc_client
     LocalAuthentication objc CryptoTokenKit SystemConfiguration
-    security_asn1 bsm.0 AppleSystemInfo)
-install(TARGETS secipc_server DESTINATION libexec/darling/usr/libexec RENAME securityd)
-install(FILES ipc/com.apple.securityd.plist DESTINATION libexec/darling/System/Library/LaunchDaemons)
+    security_asn1 bsm.0 AppleSystemInfo Security)
+install(TARGETS secipc_server DESTINATION libexec/darling/usr/libexec RENAME secd)
+install(FILES ipc/com.apple.secd.plist DESTINATION libexec/darling/System/Library/LaunchDaemons)
+
+add_darling_executable(trustd_server ipc/server.c)
+target_compile_definitions(trustd_server PRIVATE TRUSTD_SERVER)
+target_link_libraries(trustd_server system CoreFoundation
+    SecTrustOSX securityd xpc sqlite3 utilities_sec_item_shim CFNetwork SecItemShimOSX
+    security_keychain_DER SecureObjectSync z IOKit secipc_client
+    LocalAuthentication objc CryptoTokenKit SystemConfiguration
+    security_asn1 bsm.0 AppleSystemInfo Security)
+install(TARGETS trustd_server DESTINATION libexec/darling/usr/libexec RENAME trustd)
+install(FILES ../trustd/com.apple.trustd.plist DESTINATION libexec/darling/System/Library/LaunchDaemons)
+install(FILES ../trustd/com.apple.trustd.agent.plist DESTINATION libexec/darling/System/Library/LaunchAgents)
 
 add_subdirectory(Security/Tool)
 #add_subdirectory(SOSCircle/Tool)

--- a/OSX/utilities/CMakeLists.txt
+++ b/OSX/utilities/CMakeLists.txt
@@ -2,42 +2,51 @@ add_compile_options(
 	-fobjc-arc
 )
 
+set(utilities_normal_sources
+	src/debugging.c
+	src/der_dictionary.c
+	src/iCloudKeychainTrace.c
+	src/SecCFWrappers.c
+	src/SecADWrapper.c
+	src/der_date.c
+	src/fileIo.c
+	src/SecFileLocations.c
+	src/SecDb.c
+	src/SecCoreCrypto.c
+	src/SecAppleAnchor.c
+	src/SecTrace.c
+	src/der_plist_internal.c
+	src/SecSCTUtils.c
+	src/der_number.c
+	src/iOSforOSX-SecRandom.c
+	src/SecCFError.c
+	src/der_plist.c
+	src/SecCertificateTrace.c
+	src/SecAKSWrappers.c
+	src/der_array.c
+	src/SecCFCCWrappers.c
+	src/NSURL+SOSPlistStore.m
+	src/der_string.c
+	src/der_boolean.c
+	src/der_data.c
+	src/der_null.c
+	src/der_set.c
+	src/simulate_crash.c
+	src/SecBuffer.c
+	src/SecXPCError.c
+	SecurityTool/not_on_this_platorm.c
+	SecurityTool/readline.c
+)
+
 add_darling_static_library(utilities FAT
 	SOURCES
-		src/debugging.c
-		src/der_dictionary.c
-		src/iCloudKeychainTrace.c
-		src/SecCFWrappers.c
-		src/SecADWrapper.c
-		src/der_date.c
-		src/fileIo.c
-		src/SecFileLocations.c
-		src/SecDb.c
-		src/SecCoreCrypto.c
-		src/SecAppleAnchor.c
+		${utilities_normal_sources}
 		src/iOSforOSX-SecAttr.c
-		src/SecTrace.c
-		src/der_plist_internal.c
-		src/SecSCTUtils.c
-		src/der_number.c
-		src/iOSforOSX-SecRandom.c
-		src/SecCFError.c
-		src/der_plist.c
-		src/SecCertificateTrace.c
-		src/SecAKSWrappers.c
-		src/der_array.c
-		src/SecCFCCWrappers.c
-		src/NSURL+SOSPlistStore.m
-		src/der_string.c
-		src/der_boolean.c
-		src/der_data.c
-		src/der_null.c
-		src/der_set.c
-		src/simulate_crash.c
-		src/SecBuffer.c
-		src/SecXPCError.c
-		SecurityTool/not_on_this_platorm.c
-		SecurityTool/readline.c
+)
+
+add_darling_static_library(utilities_sec_item_shim FAT
+	SOURCES
+		${utilities_normal_sources}
 )
 
 add_subdirectory(SecurityTool)

--- a/include/trustd/SecTrustOSXEntryPoints.h
+++ b/include/trustd/SecTrustOSXEntryPoints.h
@@ -1,0 +1,1 @@
+../../OSX/trustd/SecTrustOSXEntryPoints.h


### PR DESCRIPTION
Depends on darlinghq/darling-libxpc#3 and darlinghq/darling#731.

From my preliminary tests, they're building and installing, and `trustd` seems to be launching properly, but it seems that it's not working properly. Trying to run `curl`, it succeeds in finding `com.apple.trustd`, but it eventually freezes on the syscall waiting for trustd to respond. I can't seem to get secd to start, though.

Edit: upon further investigation, it seems that the problem lies with somewhere in the inter-process communication used to communicate with trustd. Either trustd is listening for messages incorrectly or Mach messaging isn't passing the message to trustd, because it looks like `xpc_send` is doing its job correctly in the client.

Edit 2: Actually, `xpc_send` is failing silently because `xpc_connection_send_message_with_reply` ignores `xpc_send`'s return code. `mach_msg_send` is actually returning `KERN_INVALID_HOST`. I'll debug this more tomorrow.